### PR TITLE
feat: About tab and version display

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ A desktop application for notifications when channels go live on YouTube, Twitch
 - 🔐 **OAuth Integration** - Secure authentication with platform APIs
 - 🔄 **Auto-Updates** - Automatic updates via GitHub releases
 - ⚙️ **Flexible Configuration** - Choose between API or scraping strategies per platform
-- ℹ️ **About Tab** - View application version, author, and full dependency list with links
 
 ## Technology
 
@@ -19,8 +18,6 @@ A desktop application for notifications when channels go live on YouTube, Twitch
 - [Vite](https://vitejs.dev/)
 - [Puppeteer](https://pptr.dev/)
 - [TypeScript](https://www.typescriptlang.org/)
-- [Winston](https://github.com/winstonjs/winston) for logging
-- [Electron Store](https://github.com/sindresorhus/electron-store) for persistent settings
 
 ## Auto-Updates
 
@@ -67,24 +64,6 @@ To publish a new version:
 3. GitHub Actions will automatically build and publish the release for all platforms
 4. Make sure the release is published (not draft) for auto-updates to work
 
-### About Tab & Version Display
-
-The application window title and About tab both show the current version (from `package.json`).
-
-About tab contents:
-
-- Application name & version
-- Author & repository link
-- License
-- Dynamic dependency list (prod & dev) with direct links to npm package pages
-
-Implementation details:
-
-- Main process exposes `app:getVersion` and `app:getDependencies` via IPC.
-- Preload adds `getAppVersion()` and `getAppDependencies()` on `window.electronAPI`.
-- Renderer lazily loads dependencies when the About tab is first activated.
-
-To update the version: use `npm run version:patch|minor|major` (standard npm version scripts). The About tab will reflect the change automatically on next run.
 
 ## Kick Authorization
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A desktop application for notifications when channels go live on YouTube, Twitch
 - 🔐 **OAuth Integration** - Secure authentication with platform APIs
 - 🔄 **Auto-Updates** - Automatic updates via GitHub releases
 - ⚙️ **Flexible Configuration** - Choose between API or scraping strategies per platform
+- ℹ️ **About Tab** - View application version, author, and full dependency list with links
 
 ## Technology
 
@@ -18,6 +19,8 @@ A desktop application for notifications when channels go live on YouTube, Twitch
 - [Vite](https://vitejs.dev/)
 - [Puppeteer](https://pptr.dev/)
 - [TypeScript](https://www.typescriptlang.org/)
+- [Winston](https://github.com/winstonjs/winston) for logging
+- [Electron Store](https://github.com/sindresorhus/electron-store) for persistent settings
 
 ## Auto-Updates
 
@@ -63,6 +66,25 @@ To publish a new version:
 2. Push the tag to GitHub: `git push origin --tags`
 3. GitHub Actions will automatically build and publish the release for all platforms
 4. Make sure the release is published (not draft) for auto-updates to work
+
+### About Tab & Version Display
+
+The application window title and About tab both show the current version (from `package.json`).
+
+About tab contents:
+
+- Application name & version
+- Author & repository link
+- License
+- Dynamic dependency list (prod & dev) with direct links to npm package pages
+
+Implementation details:
+
+- Main process exposes `app:getVersion` and `app:getDependencies` via IPC.
+- Preload adds `getAppVersion()` and `getAppDependencies()` on `window.electronAPI`.
+- Renderer lazily loads dependencies when the About tab is first activated.
+
+To update the version: use `npm run version:patch|minor|major` (standard npm version scripts). The About tab will reflect the change automatically on next run.
 
 ## Kick Authorization
 

--- a/index.html
+++ b/index.html
@@ -409,24 +409,24 @@
             <div id="about-tab" class="tab-content">
                 <section class="about-section">
                     <h2>ℹ️ About</h2>
-                    <p class="section-help">Application information & open source components.</p>
-                    <div class="about-meta">
-                        <div class="about-card">
+                    <p class="section-help">Version, author and open source libraries bundled with the application.</p>
+                    <div class="about-grid">
+                        <div class="about-card app-info">
                             <h3>📛 Application</h3>
-                            <ul class="about-list">
-                                <li><strong>Name:</strong> Streamer Alerts</li>
-                                <li><strong>Version:</strong> <span id="appVersion">Loading...</span></li>
-                                <li><strong>Author:</strong> Patrick Magee</li>
-                                <li><strong>Repository:</strong> <a href="https://github.com/pjmagee/streamer-alerts-xplat" target="_blank" rel="noreferrer noopener" class="external-link">GitHub</a></li>
-                                <li><strong>License:</strong> MIT</li>
-                            </ul>
+                            <dl class="app-info-list">
+                                <div><dt>Name</dt><dd>Streamer Alerts</dd></div>
+                                <div><dt>Version</dt><dd><span id="appVersion">Loading...</span></dd></div>
+                                <div><dt>Author</dt><dd>Patrick Magee</dd></div>
+                                <div><dt>Repository</dt><dd><a href="https://github.com/pjmagee/streamer-alerts-xplat" target="_blank" rel="noreferrer noopener" class="external-link">GitHub</a></dd></div>
+                                <div><dt>License</dt><dd>MIT</dd></div>
+                            </dl>
                         </div>
-                        <div class="about-card">
+                        <div class="about-card deps-card">
                             <h3>📦 Dependencies</h3>
-                            <p class="deps-help">Including production and development dependencies.</p>
-                            <div id="dependenciesList" class="dependencies-list">
-                                <p class="loading">Loading dependency list...</p>
-                            </div>
+                            <p class="section-help">Open source runtime libraries bundled with the app.</p>
+                            <ul id="dependenciesList" class="dependencies-list">
+                                <li class="loading">Loading...</li>
+                            </ul>
                         </div>
                     </div>
                 </section>

--- a/index.html
+++ b/index.html
@@ -24,6 +24,7 @@
                 <button class="tab-button" data-tab="api">🔑 API</button>
                 <button class="tab-button" data-tab="accounts">👥 Accounts</button>
                 <button class="tab-button" data-tab="data">💾 Data</button>
+                <button class="tab-button" data-tab="about">ℹ️ About</button>
             </nav>
 
             <!-- Settings Tab -->
@@ -398,6 +399,33 @@
                                     📁 Open Folder
                                 </button>
                                 <span class="setting-help">Access settings, credentials, and data files</span>
+                            </div>
+                        </div>
+                    </div>
+                </section>
+            </div>
+
+            <!-- About Tab -->
+            <div id="about-tab" class="tab-content">
+                <section class="about-section">
+                    <h2>ℹ️ About</h2>
+                    <p class="section-help">Application information & open source components.</p>
+                    <div class="about-meta">
+                        <div class="about-card">
+                            <h3>📛 Application</h3>
+                            <ul class="about-list">
+                                <li><strong>Name:</strong> Streamer Alerts</li>
+                                <li><strong>Version:</strong> <span id="appVersion">Loading...</span></li>
+                                <li><strong>Author:</strong> Patrick Magee</li>
+                                <li><strong>Repository:</strong> <a href="https://github.com/pjmagee/streamer-alerts-xplat" target="_blank" rel="noreferrer noopener" class="external-link">GitHub</a></li>
+                                <li><strong>License:</strong> MIT</li>
+                            </ul>
+                        </div>
+                        <div class="about-card">
+                            <h3>📦 Dependencies</h3>
+                            <p class="deps-help">Including production and development dependencies.</p>
+                            <div id="dependenciesList" class="dependencies-list">
+                                <p class="loading">Loading dependency list...</p>
                             </div>
                         </div>
                     </div>

--- a/src/index.css
+++ b/src/index.css
@@ -1316,6 +1316,183 @@ input:checked + .toggle-slider:before {
     line-height: 1.5;
 }
 
+/* About Tab Styling */
+.about-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 20px;
+    margin-top: 10px;
+}
+
+.about-card {
+    background: #f8f9fa;
+    border: 1px solid #e2e8f0;
+    border-radius: 8px;
+    padding: 16px 18px 20px 18px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    position: relative;
+}
+
+.about-card h3 {
+    margin: 0 0 4px 0;
+    font-size: 1.05rem;
+    color: #2d3748;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.app-info-list {
+    display: grid;
+    gap: 6px;
+}
+
+.app-info-list div {
+    display: flex;
+    justify-content: space-between;
+    gap: 12px;
+    border-bottom: 1px dashed #e2e8f0;
+    padding-bottom: 4px;
+}
+
+.app-info-list div:last-child {
+    border-bottom: none;
+    padding-bottom: 0;
+}
+
+.app-info-list dt {
+    font-weight: 600;
+    font-size: 0.8rem;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    color: #4a5568;
+}
+
+.app-info-list dd {
+    margin: 0;
+    font-size: 0.85rem;
+    color: #2d3748;
+    font-weight: 500;
+}
+
+.deps-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-end;
+    gap: 12px;
+    flex-wrap: wrap;
+}
+
+.dep-controls {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+}
+
+.dep-search {
+    padding: 6px 10px;
+    border: 1px solid #cbd5e0;
+    border-radius: 4px;
+    font-size: 13px;
+    min-width: 180px;
+}
+
+.dep-search:focus {
+    outline: none;
+    border-color: #667eea;
+    box-shadow: 0 0 0 2px rgba(102, 126, 234, 0.15);
+}
+
+.dep-count {
+    font-size: 0.75rem;
+    background: #667eea;
+    color: white;
+    padding: 2px 8px;
+    border-radius: 12px;
+    font-weight: 600;
+    vertical-align: middle;
+}
+
+.dependencies-list-wrapper {
+    max-height: 260px;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+    border: 1px solid #e2e8f0;
+    border-radius: 6px;
+    background: #fff;
+}
+
+.dependencies-list-wrapper:hover {
+    box-shadow: 0 4px 12px rgba(0,0,0,0.05);
+}
+
+.dep-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.75rem;
+}
+
+.dep-table thead {
+    background: #f1f5f9;
+    position: sticky;
+    top: 0;
+    z-index: 1;
+}
+
+.dep-table th, .dep-table td {
+    padding: 6px 10px;
+    border-bottom: 1px solid #e2e8f0;
+    text-align: left;
+    white-space: nowrap;
+}
+
+.dep-table th {
+    font-weight: 600;
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    color: #4a5568;
+}
+
+.dep-table tbody tr:hover {
+    background: #f8fafc;
+}
+
+.dep-table a.dep-link {
+    text-decoration: none;
+    color: #667eea;
+    font-weight: 600;
+}
+
+.dep-table a.dep-link:hover {
+    text-decoration: underline;
+    color: #5a67d8;
+}
+
+.dep-table .loading {
+    text-align: center;
+    font-style: italic;
+    color: #718096;
+    padding: 14px 0;
+}
+
+@media (max-width: 620px) {
+    .deps-header {
+        flex-direction: column;
+        align-items: stretch;
+    }
+    .dep-controls {
+        width: 100%;
+        justify-content: flex-start;
+    }
+    .dep-search {
+        flex: 1;
+    }
+}
+
 .credentials-grid {
     display: grid;
     gap: 20px;
@@ -2003,6 +2180,48 @@ input:checked + .toggle-slider:before {
         transform: translateX(100%);
         opacity: 0;
     }
+}
+
+
+
+/* Simplified dependencies list (About tab) */
+.dependencies-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    max-height: 260px;
+    overflow-y: auto;
+    border: 1px solid #e2e8f0;
+    border-radius: 6px;
+    background: #fff;
+}
+.dependencies-list li {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 6px 10px;
+    font-size: 12px;
+    border-bottom: 1px solid #f1f5f9;
+}
+.dependencies-list li:last-child { border-bottom: none; }
+.dependencies-list li .dep-version {
+    color: #718096;
+    font-family: monospace;
+    font-size: 11px;
+}
+.dependencies-list li a.dep-link {
+    color: #667eea;
+    text-decoration: none;
+    font-weight: 600;
+}
+.dependencies-list li a.dep-link:hover {
+    text-decoration: underline;
+}
+.dependencies-list li.loading {
+    text-align: center;
+    justify-content: center;
+    font-style: italic;
+    color: #718096;
 }
 
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -467,24 +467,13 @@ class StreamerAlertsApp {
         const pkgRaw = fs.readFileSync(packageJsonPath, 'utf-8');
         const pkg = JSON.parse(pkgRaw);
         const deps: Record<string, string> = pkg.dependencies || {};
-        const devDeps: Record<string, string> = pkg.devDependencies || {};
-
-        const toList = (source: Record<string, string>, dev: boolean) => {
-          return Object.entries(source).map(([name, version]) => {
-            // Basic npm page link; could be enhanced later by reading individual package metadata
-            return {
-              name,
-              version,
-              dev,
-              homepage: `https://www.npmjs.com/package/${encodeURIComponent(name)}`
-            };
-          });
-        };
-
-        return [
-          ...toList(deps, false),
-          ...toList(devDeps, true)
-        ];
+        // Only include production/runtime dependencies per user request
+        return Object.entries(deps).map(([name, version]) => ({
+          name,
+          version,
+          dev: false,
+          homepage: `https://www.npmjs.com/package/${encodeURIComponent(name)}`
+        }));
       } catch (error) {
         logger.error('Failed to read dependencies list:', error);
         return [];

--- a/src/main.ts
+++ b/src/main.ts
@@ -457,6 +457,39 @@ class StreamerAlertsApp {
     ipcMain.handle('config:getSmartChecking', () => this.configService.getSmartChecking());
     ipcMain.handle('config:setSmartChecking', (_, config) => this.configService.setSmartChecking(config));
     ipcMain.handle('config:updateSmartCheckingSetting', (_, key, value) => this.configService.updateSmartCheckingSetting(key, value));
+
+    // App/meta information
+    ipcMain.handle('app:getVersion', () => app.getVersion());
+    ipcMain.handle('app:getDependencies', () => {
+      try {
+        // Load package.json from app path (works in dev and packaged)
+        const packageJsonPath = path.join(app.getAppPath(), 'package.json');
+        const pkgRaw = fs.readFileSync(packageJsonPath, 'utf-8');
+        const pkg = JSON.parse(pkgRaw);
+        const deps: Record<string, string> = pkg.dependencies || {};
+        const devDeps: Record<string, string> = pkg.devDependencies || {};
+
+        const toList = (source: Record<string, string>, dev: boolean) => {
+          return Object.entries(source).map(([name, version]) => {
+            // Basic npm page link; could be enhanced later by reading individual package metadata
+            return {
+              name,
+              version,
+              dev,
+              homepage: `https://www.npmjs.com/package/${encodeURIComponent(name)}`
+            };
+          });
+        };
+
+        return [
+          ...toList(deps, false),
+          ...toList(devDeps, true)
+        ];
+      } catch (error) {
+        logger.error('Failed to read dependencies list:', error);
+        return [];
+      }
+    });
   }
 
   private createTray(): void {
@@ -631,7 +664,8 @@ class StreamerAlertsApp {
         preload: path.join(__dirname, 'preload.js')
       },
       show: false,
-      autoHideMenuBar: true
+      autoHideMenuBar: true,
+      title: `Streamer Alerts v${app.getVersion()}`
     });
 
     // Handle renderer loading
@@ -642,6 +676,12 @@ class StreamerAlertsApp {
     }
 
     this.mainWindow.once('ready-to-show', () => {
+      // Ensure title includes version (redundant if set in constructor, but safe)
+      try {
+        this.mainWindow?.setTitle(`Streamer Alerts v${app.getVersion()}`);
+      } catch (e) {
+        logger.warn('Failed to set window title with version:', e);
+      }
       this.mainWindow?.show();
     });
 

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -57,6 +57,10 @@ const electronAPI: ElectronAPI = {
   getAvailableBrowsers: () => ipcRenderer.invoke('browser:getAvailable'),
   getSelectedBrowserPath: () => ipcRenderer.invoke('config:getSelectedBrowserPath'),
   setSelectedBrowserPath: (path: string | null) => ipcRenderer.invoke('config:setSelectedBrowserPath', path),
+
+  // App meta
+  getAppVersion: () => ipcRenderer.invoke('app:getVersion'),
+  getAppDependencies: () => ipcRenderer.invoke('app:getDependencies')
 };
 
 contextBridge.exposeInMainWorld('electronAPI', electronAPI);

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -1453,23 +1453,19 @@ class StreamerAlertsRenderer {
         return;
       }
 
-      // Sort: prod first then dev, alphabetical within groups
-      deps.sort((a, b) => {
-        if (a.dev !== b.dev) return a.dev ? 1 : -1;
-        return a.name.localeCompare(b.name);
-      });
+      // Sort alphabetical only (production deps only now)
+      deps.sort((a, b) => a.name.localeCompare(b.name));
 
       const list = document.createElement('ul');
       list.className = 'dependency-list';
 
       deps.forEach(d => {
         const li = document.createElement('li');
-        li.className = d.dev ? 'dep-item dev-dep' : 'dep-item prod-dep';
+        li.className = 'dep-item';
         li.innerHTML = `
           <span class="dep-name">${d.name}</span>
           <span class="dep-version">${d.version}</span>
           <a href="${d.homepage}" class="dep-link" data-url="${d.homepage}" title="Open ${d.name} homepage">🔗</a>
-          ${d.dev ? '<span class="dep-tag">dev</span>' : ''}
         `;
         // Use existing openExternal IPC for link clicks
         const link = li.querySelector('.dep-link');

--- a/src/types/electron-api.ts
+++ b/src/types/electron-api.ts
@@ -125,6 +125,10 @@ export interface ElectronAPI {
   getAvailableBrowsers: () => Promise<AvailableBrowser[]>;
   getSelectedBrowserPath: () => Promise<string | null>;
   setSelectedBrowserPath: (path: string | null) => Promise<void>;
+
+  // App meta
+  getAppVersion: () => Promise<string>;
+  getAppDependencies: () => Promise<Array<{ name: string; version: string; dev: boolean; homepage: string }>>;
 }
 
 declare global {

--- a/tests/about-tab.test.ts
+++ b/tests/about-tab.test.ts
@@ -1,0 +1,20 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+
+// Simple sanity test reading package.json version to ensure version available
+import fs from 'node:fs';
+import path from 'node:path';
+
+function getPkg() {
+  const pkgPath = path.join(process.cwd(), 'package.json');
+  return JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
+}
+
+// This test ensures package.json version exists for About tab & window title
+// (Renderer/electron integration tests would require a running Electron environment.)
+
+test('package version exists', () => {
+  const pkg = getPkg();
+  assert.ok(pkg.version, 'package.json should have a version');
+  assert.match(pkg.version, /^\d+\.\d+\.\d+(-.*)?$/, 'version should follow semver');
+});


### PR DESCRIPTION
Adds an About tab displaying application version and runtime dependencies (production only) with external links. Window title now includes app version. Simplified dependency listing (no filtering/table). Also includes minor UI styling.

Changes:
- index.html: About tab markup
- renderer.ts: loadAboutTab() and simplified populateDependencies()
- main.ts/preload.ts/types: IPC + API exposure for version/dependencies
- index.css: styling for About tab

No dev dependency noise; README unchanged. Ready for release.

After merge: bump version and run release:github script to push tags.
